### PR TITLE
Bugfix/vue config override

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "material",
   "namespace": "c-",
-  "version": 116,
+  "version": 117,
   "styles": [
     "bundle.min.css"
   ],

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "material",
   "namespace": "c-",
-  "version": 117,
+  "version": 118,
   "styles": [
     "bundle.min.css"
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,9 @@ export default {
       const handler = self.$options.methods.errorHandler;
       if (handler) {
         handler.call(self, error, info);
+      } else {
+        // eslint-disable-next-line
+        console.error(error);
       }
     };
     // eslint-disable-next-line
@@ -22,6 +25,9 @@ export default {
       const handler = self.$options.methods.warnHandler;
       if (handler) {
         handler.call(self, warning, trace);
+      } else {
+        // eslint-disable-next-line
+        console.error(`[Vue warn]: ${warning}${trace}`);
       }
     };
 


### PR DESCRIPTION
Log error/warning if no error/warning handler is defined instead of just skipping them. This is a temporary solution as the full solution (something like `errorCaptured`) would include changes on Preview and deployed application.