### PR TITLE
Lazy load tab item children nsftx/chameleon-bundle-charts#8

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "material",
   "namespace": "c-",
-  "version": 121,
+  "version": 122,
   "styles": [
     "bundle.min.css"
   ],

--- a/src/components/CTabItem/CTabItem.js
+++ b/src/components/CTabItem/CTabItem.js
@@ -15,12 +15,38 @@ const getTabItemContent = (context, createElement) => createElement(
 
 export default {
   extends: Element,
+  inject: ['cActiveTab'],
+  props: {
+    ordinal: {
+      type: Number,
+    },
+  },
+  data() {
+    return {
+      loadedOnce: false,
+    };
+  },
+  computed: {
+    activeTab() {
+      return this.cActiveTab.value();
+    },
+    isActive() {
+      return this.activeTab === this.ordinal;
+    },
+  },
   render(createElement) {
     const data = {
       key: this.schema.uid,
     };
 
-    const children = getTabItemContent(this, createElement);
+    // Simulate tab content lazy loading - render tab item children
+    // only when tab is active or it was previously loaded
+    // TODO Vuetify 2 changed tab item behaviour, 'eager' prop is false by default
+    // check can this part of logic be removed after upgrading
+    if (this.isActive) this.loadedOnce = true;
+
+    const shouldRenderChildren = this.isActive || this.loadedOnce;
+    const children = shouldRenderChildren ? getTabItemContent(this, createElement) : [];
 
     return this.renderElement('v-tab-item', data, children, true);
   },

--- a/src/components/CTabs/CTabs.js
+++ b/src/components/CTabs/CTabs.js
@@ -5,21 +5,25 @@ import Element from '../Element';
 
 const createTabItems = (context, createElement) => {
   const { elements } = context.config;
-  return map(elements, element => createElement(
+  return map(elements, (element, i) => createElement(
     context.getElementTag('tab-item'),
     {
       props: {
         definition: merge({}, element, {
           contentColor: context.config.contentColor,
         }),
+        ordinal: i,
       },
     },
   ));
 };
 
 const getListeners = (context) => {
+  const instance = context;
   const listeners = {
     change(value) {
+      instance.activeTab = value;
+
       if (value) {
         const label = context.config.elements[value].title;
         context.sendToEventBus('SelectedItemChanged', {
@@ -77,6 +81,18 @@ const getTabs = (context, createElement) => {
 
 export default {
   extends: Element,
+  provide() {
+    return {
+      cActiveTab: {
+        value: () => this.activeTab,
+      },
+    };
+  },
+  data() {
+    return {
+      activeTab: 0,
+    };
+  },
   render(createElement) {
     const self = this;
     const data = {


### PR DESCRIPTION
Tab items render their children on first load and hide them (with `display: none`) until tab is activated. This causes that children components, like charts, get rendered without any dimensions.
Solution is to load tab item children only when tab is activated and has its dimensions. 
After the initial render of each tab item content, keep it rendered, no need to omit rendering when tab is not active.

Related to nsftx/chameleon-bundle-charts#8