### PR TITLE
Bugfix/table touchend

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "material",
   "namespace": "c-",
-  "version": 122,
+  "version": 123,
   "styles": [
     "bundle.min.css"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6471,7 +6471,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6492,12 +6493,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6512,17 +6515,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6639,7 +6645,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6651,6 +6658,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6665,6 +6673,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6672,12 +6681,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6696,6 +6707,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6776,7 +6788,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6788,6 +6801,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6873,7 +6887,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6909,6 +6924,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6928,6 +6944,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6971,12 +6988,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12750,7 +12769,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -137,6 +137,9 @@ const getScopedSlots = (createElement, context) => {
           const { item } = props;
           context.sendToEventBus('SelectedItemChanged', item);
         },
+        touchend: () => {
+          // evt.stopPropagation();
+        },
       },
     }, getColumns(props)),
   };
@@ -279,6 +282,11 @@ export default {
         props: {
           flat: this.config.flat,
           color: this.config.color,
+        },
+        on: {
+          touchend(evt) {
+            evt.stopPropagation();
+          },
         },
       },
       table,

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -137,9 +137,6 @@ const getScopedSlots = (createElement, context) => {
           const { item } = props;
           context.sendToEventBus('SelectedItemChanged', item);
         },
-        touchend: () => {
-          // evt.stopPropagation();
-        },
       },
     }, getColumns(props)),
   };

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -285,6 +285,8 @@ export default {
         },
         on: {
           touchend(evt) {
+            // Stopping this event, otherwise reaching table horizontal scroll end
+            // on mobile affects other components such as tabs
             evt.stopPropagation();
           },
         },


### PR DESCRIPTION
- Stopped propagation on table parent card `touchend` move - it doesn't work properly if listener is added directly on `v-data-table` so the options were to add it to the card or `tr` and `th` elements separately.

This is done in order to avoid [this](https://drive.google.com/file/d/1-hAVQWUUXsFG2HIzH6Ili1f-RjSWP2aT/view) kind of behaviour on mobile devices.
